### PR TITLE
scallop: fix bash build with gcc 15

### DIFF
--- a/crates/scallop/build.rs
+++ b/crates/scallop/build.rs
@@ -68,6 +68,8 @@ fn main() {
         .enable("restricted", None)
         // build as a static library
         .enable("library", None)
+        // NOTE: Fix build issues with GCC 15. Only required for bash < 5.3.
+        .cflag("-std=gnu17")
         .make_target("libbash.a")
         .build();
 


### PR DESCRIPTION
From https://github.com/gentoo/gentoo/commit/95189717d1bdf2c420b7c88935998a894dbeff8b