### PR TITLE
pkgcraft: replace package and eapi parser with winnow parser

### DIFF
--- a/.config/insta.yaml
+++ b/.config/insta.yaml
@@ -1,0 +1,4 @@
+---
+test:
+  runner: nextest
+  auto_review: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
+checksum = "de45108900e1f9b9242f7f2e254aa3e2c029c921c258fe9e6b4217eeebd54288"
 dependencies = [
  "axum-core",
  "bytes",
@@ -259,12 +259,12 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1362f362fd16024ae199c1970ce98f9661bf5ef94b9808fee734bc3698b733"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "http-body-util",
@@ -761,9 +761,9 @@ checksum = "4f211af61d8efdd104f96e57adf5e426ba1bc3ed7a4ead616e15e5881fd79c4d"
 
 [[package]]
 name = "darling"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -771,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
@@ -785,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
@@ -1574,6 +1574,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
+name = "insta"
+version = "1.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50259abbaa67d11d2bcafc7ba1d094ed7a0c70e3ce893f0d0997f73558cb3084"
+dependencies = [
+ "console",
+ "linked-hash-map",
+ "once_cell",
+ "pin-project",
+ "serde",
+ "similar",
+]
+
+[[package]]
 name = "ipc-channel"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,9 +1962,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2806eaa3524762875e21c3dcd057bc4b7bfa01ce4da8d46be1cd43649e1cc6b"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oorandom"
@@ -2139,6 +2153,7 @@ dependencies = [
  "indexmap",
  "indicatif",
  "indoc",
+ "insta",
  "ipc-channel",
  "is_executable",
  "itertools 0.14.0",
@@ -2170,6 +2185,7 @@ dependencies = [
  "tree-sitter-bash",
  "url",
  "walkdir",
+ "winnow",
 ]
 
 [[package]]
@@ -2926,6 +2942,12 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,11 @@ rust-version = "1.82"
 
 [workspace.lints.rust]
 unreachable_pub = "warn"
+unused = "allow"
+
+[profile.dev.package]
+insta.opt-level = 3
+similar.opt-level = 3
 
 [profile.release]
 panic = "abort"

--- a/crates/pkgcraft/Cargo.toml
+++ b/crates/pkgcraft/Cargo.toml
@@ -79,10 +79,12 @@ walkdir = "2.5.0"
 # exported test support deps
 assert_cmd = { version = "2.0.16", optional = true }
 pretty_assertions = { version = "1.4.1", optional = true }
+winnow = { version = "0.7.2", features = ["simd"] }
 
 [dev-dependencies]
 criterion = "0.5"
 ctor = "0.4.1"
+insta = { version = "1.42.1", features = ["yaml"] }
 tracing-test = "0.2.5"
 
 [[bench]]

--- a/crates/pkgcraft/src/dep/dependency_set.rs
+++ b/crates/pkgcraft/src/dep/dependency_set.rs
@@ -5,6 +5,7 @@ use std::ops::{
 };
 
 use itertools::Itertools;
+use winnow::stream::Accumulate;
 
 use crate::eapi::Eapi;
 use crate::restrict::{Restrict as BaseRestrict, Restriction};
@@ -481,6 +482,16 @@ impl Restriction<&DependencySet<Dep>> for BaseRestrict {
         crate::restrict::restrict_match! {self, val,
             Self::Dep(r) => val.into_iter_flatten().any(|v| r.matches(v)),
         }
+    }
+}
+
+impl<T: Ordered> Accumulate<Dependency<T>> for DependencySet<T> {
+    fn initial(_capacity: Option<usize>) -> Self {
+        DependencySet::new()
+    }
+
+    fn accumulate(&mut self, acc: Dependency<T>) {
+        self.insert(acc);
     }
 }
 

--- a/crates/pkgcraft/src/dep/parse.rs
+++ b/crates/pkgcraft/src/dep/parse.rs
@@ -1,388 +1,114 @@
 use cached::{proc_macro::cached, SizedCache};
+use winnow::prelude::*;
 
 use crate::dep::cpn::Cpn;
 use crate::dep::cpv::{Cpv, CpvOrDep};
-use crate::dep::pkg::{Blocker, Dep, Slot, SlotDep, SlotOperator};
+use crate::dep::pkg::{Dep, Slot, SlotDep};
 use crate::dep::uri::Uri;
-use crate::dep::use_dep::{UseDep, UseDepKind};
-use crate::dep::version::{Number, Operator, Revision, Suffix, SuffixKind, Version, WithOp};
+use crate::dep::use_dep::UseDep;
+use crate::dep::version::{Revision, Version};
 use crate::dep::{Dependency, DependencySet};
-use crate::eapi::{Eapi, Feature};
-use crate::error::peg_error;
+use crate::eapi::Eapi;
 use crate::pkg::ebuild::iuse::Iuse;
-use crate::pkg::ebuild::keyword::{Keyword, KeywordStatus};
-use crate::types::Ordered;
-
-peg::parser!(grammar depspec() for str {
-    // Keywords must not begin with a hyphen.
-    rule keyword_name() -> &'input str
-        = s:$(quiet!{
-            ['a'..='z' | 'A'..='Z' | '0'..='9' | '_']
-            ['a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '-']*
-        } / expected!("keyword name"))
-        { s }
-
-    // The "-*" keyword is allowed in KEYWORDS for package metadata.
-    pub(super) rule keyword() -> Keyword
-        = arch:keyword_name()
-            { Keyword { status: KeywordStatus::Stable, arch: arch.into() } }
-        / "~" arch:keyword_name()
-            { Keyword { status: KeywordStatus::Unstable, arch: arch.into() } }
-        / "-" arch:keyword_name()
-            { Keyword { status: KeywordStatus::Disabled, arch: arch.into() } }
-        / "-*"
-            { Keyword { status: KeywordStatus::Disabled, arch: "*".into() } }
-
-    // License names must not begin with a hyphen, dot, or plus sign.
-    pub(super) rule license_name() -> &'input str
-        = s:$(quiet!{
-            ['a'..='z' | 'A'..='Z' | '0'..='9' | '_']
-            ['a'..='z' | 'A'..='Z' | '0'..='9' | '+' | '_' | '.' | '-']*
-        }) { s }
-
-    // Eclass names must not begin with a hyphen or dot and cannot be named "default".
-    pub(super) rule eclass_name() -> &'input str
-        = s:$(quiet!{
-            ['a'..='z' | 'A'..='Z' | '0'..='9' | '_']
-            ['a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '.' | '-']*
-        } / expected!("eclass name")) {?
-            if s == "default" {
-                Err("eclass cannot be named: default")
-            } else {
-                Ok(s)
-            }
-        }
-
-    // Categories must not begin with a hyphen, dot, or plus sign.
-    pub(super) rule category() -> &'input str
-        = s:$(quiet!{
-            ['a'..='z' | 'A'..='Z' | '0'..='9' | '_']
-            ['a'..='z' | 'A'..='Z' | '0'..='9' | '+' | '_' | '.' | '-']*
-        } / expected!("category name"))
-        { s }
-
-    // Packages must not begin with a hyphen or plus sign and must not end in a
-    // hyphen followed by anything matching a version.
-    pub(super) rule package() -> &'input str
-        = s:$(quiet!{
-            ['a'..='z' | 'A'..='Z' | '0'..='9' | '_']
-            (['a'..='z' | 'A'..='Z' | '0'..='9' | '+' | '_'] /
-                ("-" !(version() ("-" version())? (__ / "*" / ":" / "[" / ![_]))))*
-        } / expected!("package name"))
-        { s }
-
-    pub(super) rule number() -> Number
-        = s:$(['0'..='9']+) {?
-            let value = s.parse().map_err(|_| "integer overflow")?;
-            Ok(Number { raw: s.to_string(), value })
-        }
-
-    rule suffix() -> SuffixKind
-        = "alpha" { SuffixKind::Alpha }
-        / "beta" { SuffixKind::Beta }
-        / "pre" { SuffixKind::Pre }
-        / "rc" { SuffixKind::Rc }
-        / "p" { SuffixKind::P }
-
-    rule version_suffix() -> Suffix
-        = "_" kind:suffix() version:number()? { Suffix { kind, version } }
-
-    pub(super) rule version() -> Version
-        = numbers:number() ++ "." letter:['a'..='z']?
-                suffixes:version_suffix()* revision:revision()? {
-            Version {
-                op: None,
-                numbers,
-                letter,
-                suffixes,
-                revision: revision.unwrap_or_default(),
-            }
-        }
-
-    pub(super) rule version_with_op() -> Version
-        = v:with_op(<version()>) { v }
-
-    rule with_op<T: WithOp>(expr: rule<T>) -> T::WithOp
-        = "<=" v:expr() {? v.with_op(Operator::LessOrEqual) }
-        / "<" v:expr() {? v.with_op(Operator::Less) }
-        / ">=" v:expr() {? v.with_op(Operator::GreaterOrEqual) }
-        / ">" v:expr() {? v.with_op(Operator::Greater) }
-        / "=" v:expr() glob:"*"? {?
-            if glob.is_none() {
-                v.with_op(Operator::Equal)
-            } else {
-                v.with_op(Operator::EqualGlob)
-            }
-        } / "~" v:expr() {? v.with_op(Operator::Approximate) }
-
-    rule revision() -> Revision
-        = "-r" rev:number() { Revision(rev) }
-
-    // Slot names must not begin with a hyphen, dot, or plus sign.
-    pub(super) rule slot_name() -> &'input str
-        = s:$(quiet!{
-            ['a'..='z' | 'A'..='Z' | '0'..='9' | '_']
-            ['a'..='z' | 'A'..='Z' | '0'..='9' | '+' | '_' | '.' | '-']*
-        } / expected!("slot name")
-        ) { s }
-
-    pub(super) rule slot() -> Slot
-        = name:$(slot_name() ("/" slot_name())?) { Slot { name: name.to_string() } }
-
-    pub(super) rule slot_dep() -> SlotDep
-        = "=" { SlotDep::Op(SlotOperator::Equal) }
-        / "*" { SlotDep::Op(SlotOperator::Star) }
-        / slot:slot() "=" { SlotDep::SlotOp(slot, SlotOperator::Equal) }
-        / slot:slot() { SlotDep::Slot(slot) }
-
-    rule slot_dep_str() -> SlotDep
-        = ":" slot_dep:slot_dep() { slot_dep }
-
-    rule blocker() -> Blocker
-        = s:$("!" "!"?) {?
-            s.parse().map_err(|_| "invalid blocker")
-        }
-
-    pub(super) rule use_flag() -> &'input str
-        = s:$(quiet!{
-            ['a'..='z' | 'A'..='Z' | '0'..='9']
-            ['a'..='z' | 'A'..='Z' | '0'..='9' | '+' | '_' | '@' | '-']*
-        } / expected!("USE flag name")
-        ) { s }
-
-    pub(super) rule iuse() -> Iuse
-        = flag:use_flag() { Iuse { flag: flag.to_string(), default: None } }
-        / "+" flag:use_flag() { Iuse { flag: flag.to_string(), default: Some(true) } }
-        / "-" flag:use_flag() { Iuse { flag: flag.to_string(), default: Some(false) } }
-
-    rule use_dep_default() -> bool
-        = "(+)" { true }
-        / "(-)" { false }
-
-    pub(super) rule use_dep() -> UseDep
-        = disabled:"!"? flag:use_flag() default:use_dep_default()? kind:$(['=' | '?']) {
-            UseDep {
-                flag: flag.to_string(),
-                kind: match kind {
-                    "=" => UseDepKind::Equal,
-                    "?" => UseDepKind::Conditional,
-                    _ => unreachable!("invalid use dep kind"),
-                },
-                enabled: disabled.is_none(),
-                default,
-            }
-        } / disabled:"-"? flag:use_flag() default:use_dep_default()? {
-            UseDep {
-                flag: flag.to_string(),
-                kind: UseDepKind::Enabled,
-                enabled: disabled.is_none(),
-                default,
-            }
-        } / expected!("use dep")
-
-    rule use_deps() -> Vec<UseDep>
-        = "[" use_deps:use_dep() ++ "," "]" { use_deps }
-
-    // repo must not begin with a hyphen and must also be a valid package name
-    pub(super) rule repo() -> &'input str
-        = s:$(quiet!{
-            ['a'..='z' | 'A'..='Z' | '0'..='9' | '_']
-            (['a'..='z' | 'A'..='Z' | '0'..='9' | '_'] / ("-" !version()))*
-        } / expected!("repo name")
-        ) { s }
-
-    rule repo_dep(eapi: &'static Eapi) -> &'input str
-        = "::" repo:repo() {?
-            if eapi.has(Feature::RepoIds) {
-                Ok(repo)
-            } else {
-                Err("repo deps aren't supported in official EAPIs")
-            }
-        }
-
-    pub(super) rule cpn() -> Cpn
-        = category:category() "/" package:package()
-            { Cpn { category: category.to_string(), package: package.to_string() } }
-
-    pub(super) rule cpv() -> Cpv
-        = cpn:cpn() "-" version:version() { Cpv { cpn, version } }
-
-    rule dep_pkg() -> Dep
-        = cpn:cpn() { cpn.into() }
-        / dep:with_op(<cpv()>) { dep }
-
-    pub(super) rule dep(eapi: &'static Eapi) -> Dep
-        = blocker:blocker()? dep:dep_pkg() slot:slot_dep_str()?
-                repo:repo_dep(eapi)? use_deps:use_deps()? {
-            dep.with(blocker, slot, use_deps, repo)
-        }
-
-    pub(super) rule cpv_or_dep() -> CpvOrDep
-        = cpv:cpv() { CpvOrDep::Cpv(cpv) }
-        / dep:dep(Default::default()) { CpvOrDep::Dep(dep) }
-
-    rule _ = quiet!{[^ ' ' | '\n' | '\t']+}
-    rule __ = quiet!{[' ' | '\n' | '\t']+}
-
-    rule parens<T>(expr: rule<T>) -> Vec<T>
-        = "(" __ v:expr() ++ __ __ ")" { v }
-
-    rule all_of<T: Ordered>(expr: rule<Dependency<T>>) -> Dependency<T>
-        = vals:parens(<expr()>)
-        { Dependency::AllOf(vals.into_iter().map(Box::new).collect()) }
-
-    rule any_of<T: Ordered>(expr: rule<Dependency<T>>) -> Dependency<T>
-        = "||" __ vals:parens(<expr()>)
-        { Dependency::AnyOf(vals.into_iter().map(Box::new).collect()) }
-
-    rule conditional<T: Ordered>(expr: rule<Dependency<T>>) -> Dependency<T>
-        = disabled:"!"? flag:use_flag() "?" __ vals:parens(<expr()>) {
-            let use_dep = UseDep {
-                flag: flag.to_string(),
-                kind: UseDepKind::Conditional,
-                enabled: disabled.is_none(),
-                default: None,
-            };
-            let deps = vals.into_iter().map(Box::new).collect();
-            Dependency::Conditional(use_dep, deps)
-        }
-
-    rule exactly_one_of<T: Ordered>(expr: rule<Dependency<T>>) -> Dependency<T>
-        = "^^" __ vals:parens(<expr()>)
-        { Dependency::ExactlyOneOf(vals.into_iter().map(Box::new).collect()) }
-
-    rule at_most_one_of<T: Ordered>(expr: rule<Dependency<T>>) -> Dependency<T>
-        = "??" __ vals:parens(<expr()>)
-        { Dependency::AtMostOneOf(vals.into_iter().map(Box::new).collect()) }
-
-    pub(super) rule license_dependency() -> Dependency<String>
-        = conditional(<license_dependency()>)
-        / any_of(<license_dependency()>)
-        / all_of(<license_dependency()>)
-        / s:license_name() { Dependency::Enabled(s.to_string()) }
-
-    pub(super) rule src_uri_dependency() -> Dependency<Uri>
-        = conditional(<src_uri_dependency()>)
-        / all_of(<src_uri_dependency()>)
-        / s:$(quiet!{!")" _+}) rename:(__ "->" __ s:$(_+) {s})? {
-            let uri = Uri::new(s, rename);
-            Dependency::Enabled(uri)
-        }
-
-    // Technically RESTRICT tokens have no restrictions, but license
-    // restrictions are currently used in order to properly parse use restrictions.
-    pub(super) rule properties_dependency() -> Dependency<String>
-        = conditional(<properties_dependency()>)
-        / all_of(<properties_dependency()>)
-        / s:license_name() { Dependency::Enabled(s.to_string()) }
-
-    pub(super) rule required_use_dependency() -> Dependency<String>
-        = conditional(<required_use_dependency()>)
-        / any_of(<required_use_dependency()>)
-        / all_of(<required_use_dependency()>)
-        / exactly_one_of(<required_use_dependency()>)
-        / at_most_one_of(<required_use_dependency()>)
-        / "!" s:use_flag() { Dependency::Disabled(s.to_string()) }
-        / s:use_flag() { Dependency::Enabled(s.to_string()) }
-
-    // Technically RESTRICT tokens have no restrictions, but license
-    // restrictions are currently used in order to properly parse use restrictions.
-    pub(super) rule restrict_dependency() -> Dependency<String>
-        = conditional(<restrict_dependency()>)
-        / all_of(<restrict_dependency()>)
-        / s:license_name() { Dependency::Enabled(s.to_string()) }
-
-    pub(super) rule package_dependency(eapi: &'static Eapi) -> Dependency<Dep>
-        = conditional(<package_dependency(eapi)>)
-        / any_of(<package_dependency(eapi)>)
-        / all_of(<package_dependency(eapi)>)
-        / dep:dep(eapi) { Dependency::Enabled(dep) }
-
-    pub(super) rule license_dependency_set() -> DependencySet<String>
-        = v:license_dependency() ** __ { v.into_iter().collect() }
-
-    pub(super) rule src_uri_dependency_set() -> DependencySet<Uri>
-        = v:src_uri_dependency() ** __ { v.into_iter().collect() }
-
-    pub(super) rule properties_dependency_set() -> DependencySet<String>
-        = v:properties_dependency() ** __ { v.into_iter().collect() }
-
-    pub(super) rule required_use_dependency_set() -> DependencySet<String>
-        = v:required_use_dependency() ** __ { v.into_iter().collect() }
-
-    pub(super) rule restrict_dependency_set() -> DependencySet<String>
-        = v:restrict_dependency() ** __ { v.into_iter().collect() }
-
-    pub(super) rule package_dependency_set(eapi: &'static Eapi) -> DependencySet<Dep>
-        = v:package_dependency(eapi) ** __ { v.into_iter().collect() }
-});
+use crate::pkg::ebuild::keyword::Keyword;
+use crate::Error;
 
 pub fn category(s: &str) -> crate::Result<&str> {
-    depspec::category(s).map_err(|e| peg_error("invalid category name", s, e))
+    crate::parser::category_name
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 pub fn package(s: &str) -> crate::Result<&str> {
-    depspec::package(s).map_err(|e| peg_error("invalid package name", s, e))
+    crate::parser::package_name
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 pub(super) fn version(s: &str) -> crate::Result<Version> {
-    depspec::version(s).map_err(|e| peg_error("invalid version", s, e))
+    crate::parser::version
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 pub(super) fn version_with_op(s: &str) -> crate::Result<Version> {
-    depspec::version_with_op(s).map_err(|e| peg_error("invalid version", s, e))
+    crate::parser::version_with_op
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 pub fn license_name(s: &str) -> crate::Result<&str> {
-    depspec::license_name(s).map_err(|e| peg_error("invalid license name", s, e))
+    crate::parser::license_name
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 pub fn eclass_name(s: &str) -> crate::Result<&str> {
-    depspec::eclass_name(s).map_err(|e| peg_error("invalid eclass name", s, e))
+    crate::parser::eclass_name
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 pub fn slot(s: &str) -> crate::Result<Slot> {
-    depspec::slot(s).map_err(|e| peg_error("invalid slot", s, e))
+    crate::parser::slot
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 pub(super) fn use_dep(s: &str) -> crate::Result<UseDep> {
-    depspec::use_dep(s).map_err(|e| peg_error("invalid use dep", s, e))
+    crate::parser::use_dep
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 pub(super) fn slot_dep(s: &str) -> crate::Result<SlotDep> {
-    depspec::slot_dep(s).map_err(|e| peg_error("invalid slot", s, e))
+    crate::parser::slot_dep
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 pub fn use_flag(s: &str) -> crate::Result<&str> {
-    depspec::use_flag(s).map_err(|e| peg_error("invalid USE flag", s, e))
+    crate::parser::use_flag_name
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 pub(crate) fn iuse(s: &str) -> crate::Result<Iuse> {
-    depspec::iuse(s).map_err(|e| peg_error("invalid IUSE", s, e))
+    crate::parser::iuse
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 pub(crate) fn keyword(s: &str) -> crate::Result<Keyword> {
-    depspec::keyword(s).map_err(|e| peg_error("invalid keyword", s, e))
+    crate::parser::keyword
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 pub(crate) fn revision(s: &str) -> crate::Result<Revision> {
-    depspec::number(s)
-        .map_err(|e| peg_error("invalid revision", s, e))
+    crate::parser::number
+        .parse(s)
         .map(Revision)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 pub fn repo(s: &str) -> crate::Result<&str> {
-    depspec::repo(s).map_err(|e| peg_error("invalid repo name", s, e))
+    crate::parser::repository_name
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 /// Parse a string into a [`Cpv`].
 pub(super) fn cpv(s: &str) -> crate::Result<Cpv> {
-    depspec::cpv(s).map_err(|e| peg_error("invalid cpv", s, e))
+    crate::parser::cpv
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
-
 /// Parse a string into a [`CpvOrDep`].
 pub(super) fn cpv_or_dep(s: &str) -> crate::Result<CpvOrDep> {
-    depspec::cpv_or_dep(s).map_err(|e| peg_error("invalid cpv or dep", s, e))
+    crate::parser::cpv_or_dep
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 #[cached(
@@ -391,74 +117,100 @@ pub(super) fn cpv_or_dep(s: &str) -> crate::Result<CpvOrDep> {
     convert = r#"{ (s.to_string(), eapi) }"#
 )]
 pub(crate) fn dep(s: &str, eapi: &'static Eapi) -> crate::Result<Dep> {
-    depspec::dep(s, eapi).map_err(|e| peg_error("invalid dep", s, e))
+    crate::parser::dep(eapi)
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
-
 pub(super) fn cpn(s: &str) -> crate::Result<Cpn> {
-    depspec::cpn(s).map_err(|e| peg_error("invalid cpn", s, e))
+    crate::parser::cpn
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 pub(super) fn license_dependency_set(s: &str) -> crate::Result<DependencySet<String>> {
-    depspec::license_dependency_set(s).map_err(|e| peg_error("invalid LICENSE", s, e))
+    crate::parser::license_dependency_set
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 pub(super) fn license_dependency(s: &str) -> crate::Result<Dependency<String>> {
-    depspec::license_dependency(s).map_err(|e| peg_error("invalid LICENSE dependency", s, e))
+    crate::parser::license_dependency
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 pub(super) fn src_uri_dependency_set(s: &str) -> crate::Result<DependencySet<Uri>> {
-    depspec::src_uri_dependency_set(s).map_err(|e| peg_error("invalid SRC_URI", s, e))
+    crate::parser::src_uri_dependency_set
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 pub(super) fn src_uri_dependency(s: &str) -> crate::Result<Dependency<Uri>> {
-    depspec::src_uri_dependency(s).map_err(|e| peg_error("invalid SRC_URI dependency", s, e))
+    crate::parser::src_uri_dependency
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 pub(super) fn properties_dependency_set(s: &str) -> crate::Result<DependencySet<String>> {
-    depspec::properties_dependency_set(s).map_err(|e| peg_error("invalid PROPERTIES", s, e))
+    crate::parser::properties_dependency_set
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 pub(super) fn properties_dependency(s: &str) -> crate::Result<Dependency<String>> {
-    depspec::properties_dependency(s)
-        .map_err(|e| peg_error("invalid PROPERTIES dependency", s, e))
+    crate::parser::properties_dependency
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 pub(super) fn required_use_dependency_set(s: &str) -> crate::Result<DependencySet<String>> {
-    depspec::required_use_dependency_set(s)
-        .map_err(|e| peg_error("invalid REQUIRED_USE", s, e))
+    crate::parser::required_use_dependency_set
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 pub(super) fn required_use_dependency(s: &str) -> crate::Result<Dependency<String>> {
-    depspec::required_use_dependency(s)
-        .map_err(|e| peg_error("invalid REQUIRED_USE dependency", s, e))
+    crate::parser::required_use_dependency
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 pub(super) fn restrict_dependency_set(s: &str) -> crate::Result<DependencySet<String>> {
-    depspec::restrict_dependency_set(s).map_err(|e| peg_error("invalid RESTRICT", s, e))
+    crate::parser::restrict_dependency_set
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 pub(super) fn restrict_dependency(s: &str) -> crate::Result<Dependency<String>> {
-    depspec::restrict_dependency(s).map_err(|e| peg_error("invalid RESTRICT dependency", s, e))
+    crate::parser::restrict_dependency
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 pub(super) fn package_dependency_set(
     s: &str,
     eapi: &'static Eapi,
 ) -> crate::Result<DependencySet<Dep>> {
-    depspec::package_dependency_set(s, eapi).map_err(|e| peg_error("invalid dependency", s, e))
+    crate::parser::package_dependency_set(eapi)
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 pub(super) fn package_dependency(
     s: &str,
     eapi: &'static Eapi,
 ) -> crate::Result<Dependency<Dep>> {
-    depspec::package_dependency(s, eapi)
-        .map_err(|e| peg_error("invalid package dependency", s, e))
+    crate::parser::package_dependency(eapi)
+        .parse(s)
+        .map_err(|err| Error::ParseError(err.to_string()))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::eapi::{EAPIS, EAPIS_OFFICIAL, EAPI_LATEST_OFFICIAL, EAPI_PKGCRAFT};
+    use crate::{
+        dep::{Blocker, SlotOperator},
+        eapi::{EAPIS, EAPIS_OFFICIAL, EAPI_LATEST_OFFICIAL, EAPI_PKGCRAFT},
+    };
 
     use super::*;
 

--- a/crates/pkgcraft/src/dep/version.rs
+++ b/crates/pkgcraft/src/dep/version.rs
@@ -21,6 +21,7 @@ pub trait WithOp {
 }
 
 #[derive(Debug, Default, Clone)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub(crate) struct Number {
     pub(crate) raw: String,
     pub(crate) value: u64,
@@ -76,6 +77,7 @@ impl fmt::Display for Number {
 }
 
 #[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct Revision(pub(crate) Number);
 
 impl Revision {
@@ -120,6 +122,7 @@ impl fmt::Display for Revision {
 
 #[derive(Debug, Display, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[strum(serialize_all = "snake_case")]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub(crate) enum SuffixKind {
     Alpha,
     Beta,
@@ -129,6 +132,7 @@ pub(crate) enum SuffixKind {
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub(crate) struct Suffix {
     pub(crate) kind: SuffixKind,
     pub(crate) version: Option<Number>,
@@ -159,6 +163,7 @@ impl fmt::Display for Suffix {
     Copy,
     Clone,
 )]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub enum Operator {
     #[strum(serialize = "<")]
     Less = 1,
@@ -192,6 +197,7 @@ impl Operator {
 }
 
 #[derive(Clone)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct Version {
     pub(crate) op: Option<Operator>,
     pub(crate) numbers: Vec<Number>,

--- a/crates/pkgcraft/src/error.rs
+++ b/crates/pkgcraft/src/error.rs
@@ -17,6 +17,8 @@ pub(crate) use self::peg::peg_error;
 )]
 pub enum Error {
     #[error("{0}")]
+    ParseError(String),
+    #[error("{0}")]
     PegParse(String),
     #[error("config error: {0}")]
     Config(String),

--- a/crates/pkgcraft/src/lib.rs
+++ b/crates/pkgcraft/src/lib.rs
@@ -10,6 +10,7 @@ pub mod fetch;
 pub mod files;
 pub(crate) mod io;
 pub mod macros;
+pub mod parser;
 pub mod pkg;
 pub mod repo;
 pub mod restrict;

--- a/crates/pkgcraft/src/parser.rs
+++ b/crates/pkgcraft/src/parser.rs
@@ -1,0 +1,730 @@
+#![warn(clippy::pedantic)]
+#![warn(unused_imports)]
+
+use winnow::{
+    ascii::{alpha1, digit1, multispace1},
+    combinator::{
+        alt, cond, cut_err, delimited, dispatch, empty, eof, fail, not, opt, peek, preceded,
+        repeat, repeat_till, separated, seq, terminated, trace,
+    },
+    error::{AddContext, ContextError, ErrMode, ParserError, StrContext, StrContextValue},
+    prelude::*,
+    stream::{AsChar, ContainsToken, ParseSlice, Stream, StreamIsPartial},
+    token::{any, one_of, take_till, take_while},
+};
+
+use crate::{
+    dep::{
+        version::{Number, Suffix, SuffixKind, WithOp},
+        Blocker, Cpn, Cpv, CpvOrDep, Dep, Dependency, DependencySet, Operator, Revision, Slot,
+        SlotDep, SlotOperator, Uri, UseDep, UseDepKind, Version,
+    },
+    eapi::{Eapi, Feature},
+    pkg::ebuild::{
+        iuse::Iuse,
+        keyword::{Keyword, KeywordStatus},
+    },
+    types::{Ordered, SortedSet},
+};
+
+pub(crate) fn blocker(input: &mut &str) -> ModalResult<Blocker> {
+    trace("blocker", ('!', opt('!')).take().parse_to()).parse_next(input)
+}
+
+pub(crate) fn slot_dep(input: &mut &str) -> ModalResult<SlotDep> {
+    trace(
+        "slot_dep",
+        dispatch!(opt(alt(('=', '*'))).take();
+            "=" => empty.value(SlotDep::Op(SlotOperator::Equal)),
+            "*" => empty.value(SlotDep::Op(SlotOperator::Star)),
+            "" => (slot, opt("="))
+                .map(|(slot, op)| if op.is_some() {
+                    SlotDep::SlotOp(slot, SlotOperator::Equal)
+                } else {
+                    SlotDep::Slot(slot)
+                }),
+            _ => fail,
+        ),
+    )
+    .parse_next(input)
+}
+
+pub(crate) fn slot_dep_str(input: &mut &str) -> ModalResult<SlotDep> {
+    trace("slot_dep_str", preceded(':', slot_dep)).parse_next(input)
+}
+
+pub(crate) fn iuse(input: &mut &str) -> ModalResult<Iuse> {
+    trace(
+        "iuse",
+        seq!(Iuse {
+            default: opt(alt(('+'.value(true), '-'.value(false)))),
+            flag: use_flag_name.map(str::to_string),
+        }),
+    )
+    .parse_next(input)
+}
+
+fn use_dep_default(input: &mut &str) -> ModalResult<bool> {
+    trace("use_dep_default", delimited('(', alt(('+'.value(true), '-'.value(false))), ')'))
+        .parse_next(input)
+}
+
+pub(crate) fn use_dep(input: &mut &str) -> ModalResult<UseDep> {
+    trace("use_dep", |input: &mut &str| {
+        let disabled = opt(alt(('!', '-'))).parse_next(input)?;
+        let flag = use_flag_name.map(str::to_string).parse_next(input)?;
+        let default = opt(use_dep_default).parse_next(input)?;
+        let kind = if let Some(disabled) = disabled {
+            if disabled == '!' {
+                alt(('='.value(UseDepKind::Equal), '?'.value(UseDepKind::Conditional)))
+                    .parse_next(input)?
+            } else {
+                UseDepKind::Enabled
+            }
+        } else {
+            opt(alt(('='.value(UseDepKind::Equal), '?'.value(UseDepKind::Conditional))))
+                .parse_next(input)?
+                .unwrap_or(UseDepKind::Enabled)
+        };
+        Ok(UseDep {
+            flag,
+            kind,
+            enabled: disabled.is_none(),
+            default,
+        })
+    })
+    .parse_next(input)
+}
+
+fn use_deps(input: &mut &str) -> ModalResult<SortedSet<UseDep>> {
+    trace("use_deps", delimited('[', separated(1.., use_dep, ','), ']')).parse_next(input)
+}
+
+fn repo_dep<'i>(eapi: &'static Eapi) -> impl ModalParser<&'i str, &'i str, ContextError> {
+    trace("repo_dep", move |input: &mut &'i str| {
+        let start = input.checkpoint();
+        preceded("::", cond(eapi.has(Feature::RepoIds), repository_name))
+            .parse_next(input)?
+            .ok_or_else(|| {
+                ErrMode::from_input(input).cut().add_context(
+                    input,
+                    &start,
+                    StrContext::Expected(StrContextValue::Description(
+                        "Eapi doesn't support repository ids",
+                    )),
+                )
+            })
+    })
+}
+
+fn dep_op_pkg(input: &mut &str) -> ModalResult<Dep> {
+    trace("dep_op_pkg", |input: &mut &str| {
+        let mut op = operator.parse_next(input)?;
+        let Cpv { cpn, version } = cpv.parse_next(input)?;
+        if op == Operator::Equal && opt('*').parse_next(input)?.is_some() {
+            op = Operator::EqualGlob;
+        }
+        Ok(Dep {
+            cpn,
+            version: version.with_op(op).ok(),
+            blocker: None,
+            slot_dep: None,
+            use_deps: None,
+            repo: None,
+        })
+    })
+    .parse_next(input)
+}
+
+fn dep_pkg(input: &mut &str) -> ModalResult<Dep> {
+    trace("dep_pkg", alt((cpn.map(Into::into), dep_op_pkg))).parse_next(input)
+}
+
+pub(crate) fn dep<'i>(eapi: &'static Eapi) -> impl ModalParser<&'i str, Dep, ContextError> {
+    trace("dep", move |input: &mut &'i str| {
+        let (blocker, Dep { cpn, version, .. }, slot_dep, repo, use_deps) = (
+            opt(blocker),
+            dep_pkg,
+            opt(slot_dep_str),
+            opt(repo_dep(eapi).map(str::to_string)),
+            opt(use_deps),
+        )
+            .parse_next(input)?;
+        Ok(Dep {
+            cpn,
+            blocker,
+            version,
+            slot_dep,
+            use_deps,
+            repo,
+        })
+    })
+}
+
+pub(crate) fn cpv_or_dep(input: &mut &str) -> ModalResult<CpvOrDep> {
+    trace(
+        "cpv_or_dep",
+        alt((cpv.map(CpvOrDep::Cpv), dep(Default::default()).map(CpvOrDep::Dep))),
+    )
+    .parse_next(input)
+}
+
+pub(crate) fn cpv(input: &mut &str) -> ModalResult<Cpv> {
+    trace(
+        "cpv",
+        seq!(Cpv {
+            cpn: cpn,
+            _: '-',
+            version: version,
+        }),
+    )
+    .parse_next(input)
+}
+
+pub(crate) fn cpn(input: &mut &str) -> ModalResult<Cpn> {
+    trace(
+        "cpn",
+        seq!(Cpn {
+            category: category_name.map(str::to_string),
+            _: '/',
+            package: package_name.map(str::to_string),
+        }),
+    )
+    .parse_next(input)
+}
+
+pub(crate) fn slot(input: &mut &str) -> ModalResult<Slot> {
+    trace("slot", (slot_name, opt(('/', slot_name))).take())
+        .parse_next(input)
+        .map(str::to_string)
+        .map(|name| Slot { name })
+}
+
+pub(crate) fn keyword(input: &mut &str) -> ModalResult<Keyword> {
+    trace("keyword", move |input: &mut &str| {
+        let status =
+            opt(alt(("-".value(KeywordStatus::Disabled), "~".value(KeywordStatus::Unstable))))
+                .map(|status| status.unwrap_or(KeywordStatus::Stable))
+                .parse_next(input)?;
+        let arch =
+            alt(("*".verify(|_: &str| status == KeywordStatus::Disabled), keyword_name))
+                .parse_next(input)?;
+        Ok(Keyword { status, arch: arch.into() })
+    })
+    .parse_next(input)
+}
+
+pub(crate) fn eapi_value<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
+    trace(
+        "eapi_value",
+        alt((eapi_name, delimited('"', eapi_name, '"'), delimited('\'', eapi_name, '\''))),
+    )
+    .parse_next(input)
+}
+
+pub(crate) fn license_dependency_set(input: &mut &str) -> ModalResult<DependencySet<String>> {
+    separated(0.., license_dependency, multispace1).parse_next(input)
+}
+
+pub(crate) fn license_dependency(input: &mut &str) -> ModalResult<Dependency<String>> {
+    alt((
+        conditional(license_dependency),
+        any_of(license_dependency),
+        all_of(license_dependency),
+        license_name.map(str::to_string).map(Dependency::Enabled),
+    ))
+    .parse_next(input)
+}
+
+pub(crate) fn src_uri_dependency_set(input: &mut &str) -> ModalResult<DependencySet<Uri>> {
+    trace("src_uri_dependency_set", separated(0.., src_uri_dependency, multispace1))
+        .parse_next(input)
+}
+
+pub(crate) fn src_uri_dependency(input: &mut &str) -> ModalResult<Dependency<Uri>> {
+    trace(
+        "src_uri_dependency",
+        alt((
+            conditional(src_uri_dependency),
+            all_of(src_uri_dependency),
+            src_uri_dependency_,
+        )),
+    )
+    .parse_next(input)
+}
+
+fn src_uri_dependency_(input: &mut &str) -> ModalResult<Dependency<Uri>> {
+    trace("src_uri_dependency_", move |input: &mut &str| {
+        (
+            preceded(not(')'), take_till(1.., (AsChar::is_space, AsChar::is_newline))),
+            opt(preceded(
+                (multispace1, "->", multispace1),
+                take_till(1.., (AsChar::is_space, AsChar::is_newline)),
+            )),
+        )
+            .parse_next(input)
+            .map(|(uri, rename)| Uri::new(uri, rename))
+            .map(Dependency::Enabled)
+    })
+    .parse_next(input)
+}
+
+pub(crate) fn properties_dependency_set(
+    input: &mut &str,
+) -> ModalResult<DependencySet<String>> {
+    separated(0.., properties_dependency, multispace1).parse_next(input)
+}
+
+pub(crate) fn properties_dependency(input: &mut &str) -> ModalResult<Dependency<String>> {
+    trace(
+        "properties_dependency",
+        alt((
+            conditional(properties_dependency),
+            all_of(properties_dependency),
+            license_name.map(str::to_string).map(Dependency::Enabled),
+        )),
+    )
+    .parse_next(input)
+}
+pub(crate) fn required_use_dependency_set(
+    input: &mut &str,
+) -> ModalResult<DependencySet<String>> {
+    trace(
+        "required_use_dependency_set",
+        separated(0.., required_use_dependency, multispace1),
+    )
+    .parse_next(input)
+}
+
+pub(crate) fn required_use_dependency(input: &mut &str) -> ModalResult<Dependency<String>> {
+    trace(
+        "required_use_dependency",
+        alt((
+            conditional(required_use_dependency),
+            any_of(required_use_dependency),
+            all_of(required_use_dependency),
+            exactly_one_of(required_use_dependency),
+            at_most_one_of(required_use_dependency),
+            required_use_dependency_,
+        )),
+    )
+    .parse_next(input)
+}
+
+fn required_use_dependency_(input: &mut &str) -> ModalResult<Dependency<String>> {
+    trace("required_use_dependency_", move |input: &mut &str| {
+        let disabled = opt('!').parse_next(input)?;
+        let use_flag = use_flag_name.map(str::to_string).parse_next(input)?;
+        if disabled.is_some() {
+            Ok(Dependency::Disabled(use_flag))
+        } else {
+            Ok(Dependency::Enabled(use_flag))
+        }
+    })
+    .parse_next(input)
+}
+
+pub(crate) fn restrict_dependency_set(input: &mut &str) -> ModalResult<DependencySet<String>> {
+    separated(0.., restrict_dependency, multispace1).parse_next(input)
+}
+
+pub(crate) fn restrict_dependency(input: &mut &str) -> ModalResult<Dependency<String>> {
+    alt((
+        conditional(restrict_dependency),
+        all_of(restrict_dependency),
+        license_name.map(str::to_string).map(Dependency::Enabled),
+    ))
+    .parse_next(input)
+}
+
+pub(crate) fn package_dependency_set<'i>(
+    eapi: &'static Eapi,
+) -> impl ModalParser<&'i str, DependencySet<Dep>, ContextError> {
+    separated(0.., package_dependency(eapi), multispace1)
+}
+
+pub(crate) fn package_dependency<'i>(
+    eapi: &'static Eapi,
+) -> impl ModalParser<&'i str, Dependency<Dep>, ContextError> {
+    move |input: &mut &str| {
+        alt((
+            conditional(package_dependency(eapi)),
+            any_of(package_dependency(eapi)),
+            all_of(package_dependency(eapi)),
+            dep(eapi).map(Dependency::Enabled),
+        ))
+        .parse_next(input)
+    }
+}
+
+fn conditional<'i, O>(
+    mut parser: impl ModalParser<&'i str, Dependency<O>, ContextError>,
+) -> impl ModalParser<&'i str, Dependency<O>, ContextError>
+where
+    O: Ordered,
+{
+    move |input: &mut &'i str| {
+        let (disabled, flag, _, _) =
+            (opt('!'), use_flag_name, '?', multispace1).parse_next(input)?;
+        let use_dep = UseDep {
+            flag: flag.to_string(),
+            kind: UseDepKind::Conditional,
+            enabled: disabled.is_none(),
+            default: None,
+        };
+        let dependencies = group(parser.by_ref()).parse_next(input)?;
+        let dependencies = dependencies.into_iter().map(Box::new).collect();
+        Ok(Dependency::Conditional(use_dep, dependencies))
+    }
+}
+
+fn all_of<'i, O, E>(
+    mut parser: impl Parser<&'i str, Dependency<O>, E>,
+) -> impl Parser<&'i str, Dependency<O>, E>
+where
+    O: Ordered,
+    E: ParserError<&'i str>,
+{
+    move |input: &mut &'i str| {
+        let dependencies = group(parser.by_ref()).parse_next(input)?;
+        let dependencies = dependencies.into_iter().map(Box::new).collect();
+        Ok(Dependency::AllOf(dependencies))
+    }
+}
+
+fn any_of<'i, O, E>(
+    mut parser: impl Parser<&'i str, Dependency<O>, E>,
+) -> impl Parser<&'i str, Dependency<O>, E>
+where
+    O: Ordered,
+    E: ParserError<&'i str>,
+{
+    move |input: &mut &'i str| {
+        let dependencies =
+            preceded(("||", multispace1), group(parser.by_ref())).parse_next(input)?;
+        let dependencies = dependencies.into_iter().map(Box::new).collect();
+        Ok(Dependency::AnyOf(dependencies))
+    }
+}
+
+fn exactly_one_of<'i, O, E>(
+    mut parser: impl Parser<&'i str, Dependency<O>, E>,
+) -> impl Parser<&'i str, Dependency<O>, E>
+where
+    O: Ordered,
+    E: ParserError<&'i str>,
+{
+    move |input: &mut &'i str| {
+        let dependencies =
+            preceded(("^^", multispace1), group(parser.by_ref())).parse_next(input)?;
+        let dependencies = dependencies.into_iter().map(Box::new).collect();
+        Ok(Dependency::ExactlyOneOf(dependencies))
+    }
+}
+
+fn at_most_one_of<'i, O, E>(
+    mut parser: impl Parser<&'i str, Dependency<O>, E>,
+) -> impl Parser<&'i str, Dependency<O>, E>
+where
+    O: Ordered,
+    E: ParserError<&'i str>,
+{
+    move |input: &mut &'i str| {
+        let dependencies =
+            preceded(("??", multispace1), group(parser.by_ref())).parse_next(input)?;
+        let dependencies = dependencies.into_iter().map(Box::new).collect();
+        Ok(Dependency::AtMostOneOf(dependencies))
+    }
+}
+
+fn group<'i, O, E>(parser: impl Parser<&'i str, O, E>) -> impl Parser<&'i str, Vec<O>, E>
+where
+    E: ParserError<&'i str>,
+{
+    trace(
+        "group",
+        delimited(('(', multispace1), repeat(1.., terminated(parser, multispace1)), ')'),
+    )
+}
+
+// 3.1.1 Category names
+pub(crate) fn category_name<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
+    trace("category_name", name((AsChar::is_alphanum, '_'), ('-', '.', '+'))).parse_next(input)
+}
+
+// 3.1.2 Package names
+pub(crate) fn package_name<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
+    trace(
+        "package_name",
+        (
+            one_of((AsChar::is_alphanum, '_')),
+            repeat::<_, _, Vec<_>, _, _>(
+                0..,
+                alt((
+                    one_of((AsChar::is_alphanum, '_', '+')).take(),
+                    // TODO: investigate how this effects performance
+                    terminated(
+                        "-",
+                        not((
+                            separated::<_, _, Vec<_>, _, _, _, _>(1.., version, '-').void(),
+                            alt(("*", ":", "[", eof)),
+                        )),
+                    ),
+                )),
+            )
+            .take(),
+        )
+            .take(),
+    )
+    .parse_next(input)
+}
+
+// 3.1.3 Slot names
+pub(crate) fn slot_name<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
+    trace("slot_name", name((AsChar::is_alphanum, '_'), ('-', '.', '+'))).parse_next(input)
+}
+
+// 3.1.4 USE flag names
+pub(crate) fn use_flag_name<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
+    trace("use_flag_name", name(AsChar::is_alphanum, ('_', '-', '.', '+', '@')))
+        .parse_next(input)
+}
+
+// 3.1.5 Repository names
+pub(crate) fn repository_name<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
+    trace(
+        "repository_name",
+        (
+            one_of((AsChar::is_alphanum, '_')),
+            repeat::<_, _, Vec<_>, _, _>(
+                0..,
+                alt((
+                    one_of((AsChar::is_alphanum, '_')).take(),
+                    // TODO: investigate how this effects performance
+                    terminated(
+                        "-",
+                        not((
+                            separated::<_, _, Vec<_>, _, _, _, _>(1.., version, '-').void(),
+                            alt(("*", ":", "[", eof)),
+                        )),
+                    ),
+                )),
+            )
+            .take(),
+        )
+            .take(),
+    )
+    .parse_next(input)
+}
+
+// 3.1.6 Eclass names
+pub(crate) fn eclass_name<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
+    trace(
+        "eclass_name",
+        preceded(
+            not("default"),
+            name((AsChar::is_alpha, '_'), (AsChar::is_dec_digit, '-', '.')),
+        ),
+    )
+    .parse_next(input)
+}
+
+// 3.1.7 License names
+pub(crate) fn license_name<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
+    trace("license_name", name((AsChar::is_alphanum, '_'), ('-', '.', '+'))).parse_next(input)
+}
+
+/// 3.1.8
+pub(crate) fn keyword_name<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
+    trace("keyword_name", name((AsChar::is_alphanum, '_'), '-')).parse_next(input)
+}
+
+// 3.1.9 Eapi names
+pub(crate) fn eapi_name<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
+    trace("eapi_name", name((AsChar::is_alphanum, '_'), ('-', '.', '+'))).parse_next(input)
+}
+
+/// Take a single prefix token followed by one or more prefix + suffix tokens.
+// TODO: pass context as arguments OR delete function
+pub(crate) fn name<I, E, Prefix, Suffix>(
+    prefix: Prefix,
+    suffix: Suffix,
+) -> impl Parser<I, <I as Stream>::Slice, E>
+where
+    I: StreamIsPartial + Stream,
+    <I as Stream>::Token: Clone,
+    E: ParserError<I>,
+    Prefix: ContainsToken<<I as Stream>::Token> + Clone,
+    Suffix: ContainsToken<<I as Stream>::Token> + Clone,
+{
+    trace("name", (one_of(prefix.clone()), take_while(0.., (prefix, suffix))).take())
+}
+
+pub(crate) fn version_with_op(input: &mut &str) -> ModalResult<Version> {
+    trace("version_with_op", move |input: &mut &str| {
+        let Version {
+            mut op,
+            numbers,
+            letter,
+            suffixes,
+            revision,
+        } = seq!(Version {
+            op: operator.map(Some),
+            numbers: numbers,
+            letter: opt(letter),
+            suffixes: suffixes,
+            revision: revision,
+        })
+        .verify(|version| {
+            // The approximate operator may only be used on package names without a revision
+            if version
+                .op
+                .as_ref()
+                .is_some_and(|op| *op == Operator::Approximate)
+            {
+                return version.revision.is_empty();
+            }
+            true
+        })
+        .parse_next(input)?;
+
+        // Transform the Equal operator to EqualGlob if the version has a trailing '*'
+        if op.as_ref().is_some_and(|op| *op == Operator::Equal)
+            && opt('*').parse_next(input)?.is_some()
+        {
+            op = Some(Operator::EqualGlob);
+        }
+
+        Ok(Version {
+            op,
+            numbers,
+            letter,
+            suffixes,
+            revision,
+        })
+    })
+    .parse_next(input)
+}
+
+pub(crate) fn version(input: &mut &str) -> ModalResult<Version> {
+    trace(
+        "version",
+        seq!(Version {
+            op: empty.value(None),
+            numbers: numbers,
+            letter: opt(letter),
+            suffixes: suffixes,
+            revision: revision,
+        }),
+    )
+    .parse_next(input)
+}
+
+pub(crate) fn operator(input: &mut &str) -> ModalResult<Operator> {
+    trace(
+        "operator",
+        dispatch!(take_while(1..=2, ('<', '=', '>', '~'));
+            "<=" => empty.value(Operator::LessOrEqual),
+            ">=" => empty.value(Operator::GreaterOrEqual),
+            "<" => empty.value(Operator::Less),
+            "=" => empty.value(Operator::Equal),
+            "~" => empty.value(Operator::Approximate),
+            ">" => empty.value(Operator::Greater),
+            _ => fail,
+        ),
+    )
+    .parse_next(input)
+}
+
+pub(crate) fn numbers(input: &mut &str) -> ModalResult<Vec<Number>> {
+    trace("numbers", separated(1.., number, '.')).parse_next(input)
+}
+
+pub(crate) fn letter(input: &mut &str) -> ModalResult<char> {
+    trace("letter", one_of('a'..='z')).parse_next(input)
+}
+
+pub(crate) fn suffixes(input: &mut &str) -> ModalResult<Vec<Suffix>> {
+    trace("suffixes", repeat(0.., suffix)).parse_next(input)
+}
+
+pub(crate) fn suffix(input: &mut &str) -> ModalResult<Suffix> {
+    trace(
+        "suffix",
+        seq!(Suffix {
+            _: '_',
+            kind: suffix_kind,
+            version: opt(number),
+        }),
+    )
+    .parse_next(input)
+}
+
+pub(crate) fn suffix_kind(input: &mut &str) -> ModalResult<SuffixKind> {
+    trace(
+        "suffix_kind",
+        dispatch!(alpha1;
+            "alpha" => empty.value(SuffixKind::Alpha),
+            "beta" => empty.value(SuffixKind::Beta),
+            "pre" => empty.value(SuffixKind::Pre),
+            "rc" => empty.value(SuffixKind::Rc),
+            "p" => empty.value(SuffixKind::P),
+            _ => fail,
+        ),
+    )
+    .parse_next(input)
+}
+
+pub(crate) fn revision(input: &mut &str) -> ModalResult<Revision> {
+    trace("revision", opt(preceded("-r", number)))
+        .parse_next(input)
+        .map(Option::unwrap_or_default)
+        .map(Revision)
+}
+
+pub(crate) fn number(input: &mut &str) -> ModalResult<Number> {
+    trace("number", |input: &mut &str| {
+        let start = input.checkpoint();
+        let raw = digit1.parse_next(input)?;
+        let value = raw.parse_slice().ok_or_else(|| {
+            input.reset(&start);
+            ParserError::from_input(input)
+        })?;
+        Ok(Number { raw: raw.to_string(), value })
+    })
+    .parse_next(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use winnow::error::ContextError;
+
+    use super::*;
+
+    #[test]
+    fn eapi_values() {
+        assert_eq!(eapi_value.parse("8"), Ok("8"));
+        assert_eq!(eapi_value.parse("_foo"), Ok("_foo"));
+        assert_eq!(eapi_value.parse("Foo"), Ok("Foo"));
+    }
+
+    #[test]
+    fn package_names() {
+        assert_eq!(package_name.parse_peek("pkg-1::repo"), Ok(("-1::repo", "pkg")));
+    }
+
+    #[test]
+    fn eapi_names() {
+        assert_eq!(eapi_name.parse("8"), Ok("8"));
+        assert_eq!(eapi_name.parse("_foo"), Ok("_foo"));
+        assert_eq!(eapi_name.parse("Foo"), Ok("Foo"));
+    }
+
+    #[test]
+    fn names() {
+        assert_eq!(
+            name::<_, ContextError, _, _>('A'..='Z', 'a'..='z').parse("FoO"),
+            Ok("FoO")
+        );
+    }
+}

--- a/crates/pkgcraft/src/pkg/ebuild/keyword.rs
+++ b/crates/pkgcraft/src/pkg/ebuild/keyword.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 use crate::dep::parse;
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct Arch(String);
 
 impl From<&str> for Arch {
@@ -67,6 +68,7 @@ impl fmt::Display for Arch {
 /// Package keyword type.
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, Clone)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub enum KeywordStatus {
     Disabled, // -arch
     Unstable, // ~arch
@@ -74,6 +76,7 @@ pub enum KeywordStatus {
 }
 
 #[derive(PartialEq, Eq, Hash, Clone)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct Keyword {
     pub(crate) status: KeywordStatus,
     pub(crate) arch: Arch,

--- a/crates/pkgcraft/src/pkg/ebuild/raw.rs
+++ b/crates/pkgcraft/src/pkg/ebuild/raw.rs
@@ -3,10 +3,11 @@ use std::{fmt, fs};
 
 use camino::Utf8PathBuf;
 use indexmap::IndexMap;
+use winnow::prelude::*;
 
 use crate::bash;
 use crate::dep::{Cpv, Dep};
-use crate::eapi::{self, Eapi};
+use crate::eapi::Eapi;
 use crate::error::Error;
 use crate::macros::bool_not_equal;
 use crate::pkg::{make_pkg_traits, Package, RepoPackage};
@@ -81,7 +82,10 @@ impl EbuildRawPkg {
             })
             .unwrap_or("0");
 
-        eapi::parse_value(s)?.parse()
+        crate::parser::eapi_value
+            .parse_to()
+            .parse(s)
+            .map_err(|err| crate::Error::ParseError(err.to_string()))
     }
 
     /// Return the path of the package's ebuild relative to the repository root.

--- a/crates/pkgcraft/src/types/sorted_set.rs
+++ b/crates/pkgcraft/src/types/sorted_set.rs
@@ -7,6 +7,7 @@ use indexmap::IndexSet;
 use itertools::EitherOrBoth::{Both, Left, Right};
 use itertools::Itertools;
 use serde::{Deserialize, Deserializer};
+use winnow::stream::Accumulate;
 
 use crate::macros::partial_cmp_not_equal_opt;
 
@@ -131,6 +132,16 @@ where
         D: Deserializer<'de>,
     {
         IndexSet::deserialize(deserializer).map(SortedSet)
+    }
+}
+
+impl<T: Ordered> Accumulate<T> for SortedSet<T> {
+    fn initial(_capacity: Option<usize>) -> Self {
+        SortedSet::new()
+    }
+
+    fn accumulate(&mut self, acc: T) {
+        self.insert(acc);
     }
 }
 


### PR DESCRIPTION
~I developed the parsers out of tree in a another library crate for multiple reasons, and integrating the code surfaced some logic bugs :/ Some tests are failing at the moment.~

Still looking for initial feedback. 

- [x] Collect immediately into `SortedSet` (implement `winnow::Accumulate`  for `SortedSet`)
- [ ] Add tests
- [ ] Add docs
- [x] Move to own module
- [ ] Add context
- [ ] Inline snapshot tests
- [ ] Use `assert_snapshot!` where appropriate
- [ ] Fix tests
- [ ] Use constant named values instead of chars and ranges
- [ ] Implement restrict parsers
- [ ] Remove dependency on peg

Closes: #214